### PR TITLE
Added support for experiment execution on clusters with no shared disk 

### DIFF
--- a/peel-core/src/main/resources/reference.peel.conf
+++ b/peel-core/src/main/resources/reference.peel.conf
@@ -54,12 +54,14 @@ system {
         config {
             masters = [ ${app.hostname} ]
             slaves = [ ${app.hostname} ]
-            noSharedDisk = "false"
             java = {
                 home = ${java.home}
             }
             parallelism.per-node = ${runtime.cpu.cores}
             parallelism.total = ${system.default.config.parallelism.per-node}
+        }
+        path {
+            isShared = "false"
         }
         # system startup options
         startup {

--- a/peel-core/src/main/resources/reference.peel.conf
+++ b/peel-core/src/main/resources/reference.peel.conf
@@ -61,7 +61,7 @@ system {
             parallelism.total = ${system.default.config.parallelism.per-node}
         }
         path {
-            isShared = "false"
+            isShared = false
         }
         # system startup options
         startup {

--- a/peel-core/src/main/resources/reference.peel.conf
+++ b/peel-core/src/main/resources/reference.peel.conf
@@ -54,6 +54,7 @@ system {
         config {
             masters = [ ${app.hostname} ]
             slaves = [ ${app.hostname} ]
+            noSharedDisk = "false"
             java = {
                 home = ${java.home}
             }

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -94,13 +94,13 @@ abstract class System(
     val homePath = config.getString(s"system.$configKey.path.home")
     val destinationPath = new File(homePath).getParent
     val slaves = config.getStringList(s"system.$configKey.config.slaves").asScala
-    val currentUser = config.getString(s"system.$configKey.user")
+    val user = config.getString(s"system.$configKey.user")
     val logPath = Paths.get(config.getString(s"system.$configKey.path.log"))
     val relativeLogPath = Paths.get(destinationPath).relativize(logPath).normalize
     val futureSyncedDirs = Future.traverse(slaves)(host =>
         Future {
-          createRemoteDirectory(destinationPath, currentUser, host)
-          copyDirectorytoRemote(homePath, destinationPath, currentUser, host, relativeLogPath.toString)
+          createRemoteDirectory(destinationPath, user, host)
+          copyDirectorytoRemote(homePath, destinationPath, user, host, relativeLogPath.toString)
         })
 
       // await for all future log file counts and convert the result to a map

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -81,9 +81,8 @@ abstract class System(
       }
 
       configuration().update()
-      if (config.getBoolean("system.default.path.isShared")) {
+      if (config.getBoolean("system.default.path.isShared"))
         copyHomeToSlaves()
-      }
       start()
 
       logger.info(s"System '$toString' is now up and running")

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -82,7 +82,7 @@ abstract class System(
 
       configuration().update()
       if (config.getBoolean("system.default.path.isShared")) {
-        copyHomeToSlaves
+        copyHomeToSlaves()
       }
       start()
 
@@ -90,7 +90,7 @@ abstract class System(
     }
   }
 
-  def copyHomeToSlaves: Unit = {
+  def copyHomeToSlaves(): Unit = {
     val homePath = config.getString(s"system.$configKey.path.home")
     val destinationPath = new File(homePath).getParent
     val slaves = config.getStringList(s"system.$configKey.config.slaves").asScala

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -96,12 +96,12 @@ abstract class System(
 
   def copyHomeToSlaves: Unit = {
     val homePath = config.getString(s"system.$configKey.path.home")
-    val parentHomePath = new File(homePath).getParent
+    val destinationPath = new File(homePath).getParent
     val slaves = config.getStringList(s"system.$configKey.config.slaves").asScala
     val currentUser = config.getString(s"system.$configKey.user")
     for (host <- slaves) {
-      createRemoteDirectory(parentHomePath, currentUser, host)
-      copyDirectorytoRemote(homePath, parentHomePath, currentUser, host)
+      createRemoteDirectory(destinationPath, currentUser, host)
+      copyDirectorytoRemote(homePath, destinationPath, currentUser, host)
     }
   }
 

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -90,8 +90,7 @@ abstract class System(
     }
   }
 
-  def noSharedDisk: Boolean =
-    Try(config.getString("system.default.path.isShared").toBoolean).getOrElse(false)
+  def noSharedDisk: Boolean = config.getBoolean("system.default.path.isShared")
 
   def copyHomeToSlaves: Unit = {
     val homePath = config.getString(s"system.$configKey.path.home")

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -76,13 +76,20 @@ abstract class System(
       }
 
       configuration().update()
-      if (config.hasPath("system.default.config.noSharedDisk") && config.getString(s"system.default.config.noSharedDisk") == "true") {
+      if (noSharedDisk) {
         copyHomeToSlaves
       }
       start()
 
       logger.info(s"System '$toString' is now up and running")
     }
+  }
+
+  def noSharedDisk: Boolean = {
+    if(!config.hasPath("system.default.config.noSharedDisk"))
+      return false
+
+    config.getString("system.default.config.noSharedDisk") == "true"
   }
 
   def copyHomeToSlaves: Unit = {

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -110,13 +110,14 @@ abstract class System(
   }
 
   def copyDirectorytoRemote(localSource: String, remoteDestination: String, user: String, host: String): Int = {
-    logger.info(s"rsync -a $localSource $user@$host:$remoteDestination")
-    shell ! s"rsync -a $localSource $user@$host:$remoteDestination"
+    val fullDestination: String = s"$user@$host:$remoteDestination"
+    logger.info(s"rsync -a $localSource $fullDestination")
+    shell ! (s"rsync -a $localSource $fullDestination", s"failed to copy $localSource to $fullDestination", fatal = true)
   }
 
   def createRemoteDirectory(path: String, user: String, host: String): Int = {
     logger.info(s"creating directory $path on remote host $host")
-    shell ! s"ssh $user@$host mkdir -p $path"
+    shell ! (s"ssh $user@$host mkdir -p $path", s"failed to create directory $path on remote host $host", fatal = true)
   }
 
   /** Cleans up and shuts down the system. */

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -107,20 +107,12 @@ abstract class System(
 
   def copyDirectorytoRemote(localSource: String, remoteDestination: String, user: String, host: String): Int = {
     logger.info(s"rsync -a $localSource $user@$host:$remoteDestination")
-    shell ! "rsync -a %s %s@%s:%s".format(
-      localSource,
-      user,
-      host,
-      remoteDestination)
+    shell ! s"rsync -a $localSource $user@$host:$remoteDestination"
   }
 
   def createRemoteDirectory(path: String, user: String, host: String): Int = {
     logger.info(s"creating directory $path on remote host $host")
-    shell ! "ssh %s@%s mkdir -p %s".format(
-      user,
-      host,
-      path
-    )
+    shell ! s"ssh $user@$host mkdir -p $path"
   }
 
   /** Cleans up and shuts down the system. */

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -82,12 +82,7 @@ abstract class System(
         val slaves = config.getStringList(s"system.$configKey.config.slaves").asScala
         val currentUser = config.getString(s"system.$configKey.user")
         for(host <- slaves){
-          logger.info(s"creating directory $parentHomePath on remote host $host")
-          shell ! "ssh %s@%s mkdir -p %s".format(
-            currentUser,
-            host,
-            parentHomePath
-          )
+          createRemoteDirectory(parentHomePath, currentUser, host)
           logger.info(s"rsync -a $homePath $currentUser@$host:$parentHomePath")
           shell ! "rsync -a %s %s@%s:%s".format(
             homePath,
@@ -100,6 +95,15 @@ abstract class System(
 
       logger.info(s"System '$toString' is now up and running")
     }
+  }
+
+  def createRemoteDirectory(path: String, user: String, host: String): Int = {
+    logger.info(s"creating directory $path on remote host $host")
+    shell ! "ssh %s@%s mkdir -p %s".format(
+      user,
+      host,
+      path
+    )
   }
 
   /** Cleans up and shuts down the system. */

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -100,7 +100,7 @@ abstract class System(
     val futureSyncedDirs = Future.traverse(slaves)(host =>
         Future {
           createRemoteDirectory(destinationPath, user, host)
-          copyDirectorytoRemote(homePath, destinationPath, user, host, relativeLogPath.toString)
+          copyDirectorytoRemote(homePath, destinationPath, user, host, relativeLogPath.toString + "/*")
         })
 
       // await for all future log file counts and convert the result to a map

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -91,7 +91,7 @@ abstract class System(
   }
 
   def noSharedDisk: Boolean =
-    Try(config.getString("system.default.config.noSharedDisk").toBoolean).getOrElse(false)
+    Try(config.getString("system.default.path.isShared").toBoolean).getOrElse(false)
 
   def copyHomeToSlaves: Unit = {
     val homePath = config.getString(s"system.$configKey.path.home")

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -27,7 +27,9 @@ import org.peelframework.core.graph.Node
 import org.peelframework.core.util.{Version, shell}
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.BeanNameAware
+
 import scala.collection.JavaConverters._
+import scala.util.Try
 
 
 /** This class represents a System in the Peel framework.
@@ -89,7 +91,7 @@ abstract class System(
     if(!config.hasPath("system.default.config.noSharedDisk"))
       return false
 
-    config.getString("system.default.config.noSharedDisk") == "true"
+    Try(config.getString("system.default.config.noSharedDisk").toBoolean).getOrElse(false)
   }
 
   def copyHomeToSlaves: Unit = {

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -83,18 +83,22 @@ abstract class System(
         val currentUser = config.getString(s"system.$configKey.user")
         for(host <- slaves){
           createRemoteDirectory(parentHomePath, currentUser, host)
-          logger.info(s"rsync -a $homePath $currentUser@$host:$parentHomePath")
-          shell ! "rsync -a %s %s@%s:%s".format(
-            homePath,
-            currentUser,
-            host,
-            parentHomePath)
+          copyDirectorytoRemote(homePath, parentHomePath, currentUser, host)
         }
       }
       start()
 
       logger.info(s"System '$toString' is now up and running")
     }
+  }
+
+  def copyDirectorytoRemote(localSource: String, remoteDestination: String, user: String, host: String): Int = {
+    logger.info(s"rsync -a $localSource $user@$host:$remoteDestination")
+    shell ! "rsync -a %s %s@%s:%s".format(
+      localSource,
+      user,
+      host,
+      remoteDestination)
   }
 
   def createRemoteDirectory(path: String, user: String, host: String): Int = {

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -87,12 +87,8 @@ abstract class System(
     }
   }
 
-  def noSharedDisk: Boolean = {
-    if(!config.hasPath("system.default.config.noSharedDisk"))
-      return false
-
+  def noSharedDisk: Boolean =
     Try(config.getString("system.default.config.noSharedDisk").toBoolean).getOrElse(false)
-  }
 
   def copyHomeToSlaves: Unit = {
     val homePath = config.getString(s"system.$configKey.path.home")

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -77,18 +77,22 @@ abstract class System(
 
       configuration().update()
       if (config.hasPath("system.default.config.noSharedDisk") && config.getString(s"system.default.config.noSharedDisk") == "true") {
-        val homePath = config.getString(s"system.$configKey.path.home")
-        val parentHomePath = new File(homePath).getParent
-        val slaves = config.getStringList(s"system.$configKey.config.slaves").asScala
-        val currentUser = config.getString(s"system.$configKey.user")
-        for(host <- slaves){
-          createRemoteDirectory(parentHomePath, currentUser, host)
-          copyDirectorytoRemote(homePath, parentHomePath, currentUser, host)
-        }
+        copyHomeToSlaves
       }
       start()
 
       logger.info(s"System '$toString' is now up and running")
+    }
+  }
+
+  def copyHomeToSlaves: Unit = {
+    val homePath = config.getString(s"system.$configKey.path.home")
+    val parentHomePath = new File(homePath).getParent
+    val slaves = config.getStringList(s"system.$configKey.config.slaves").asScala
+    val currentUser = config.getString(s"system.$configKey.user")
+    for (host <- slaves) {
+      createRemoteDirectory(parentHomePath, currentUser, host)
+      copyDirectorytoRemote(homePath, parentHomePath, currentUser, host)
     }
   }
 

--- a/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/beans/system/System.scala
@@ -81,7 +81,7 @@ abstract class System(
       }
 
       configuration().update()
-      if (noSharedDisk) {
+      if (config.getBoolean("system.default.path.isShared")) {
         copyHomeToSlaves
       }
       start()
@@ -89,8 +89,6 @@ abstract class System(
       logger.info(s"System '$toString' is now up and running")
     }
   }
-
-  def noSharedDisk: Boolean = config.getBoolean("system.default.path.isShared")
 
   def copyHomeToSlaves: Unit = {
     val homePath = config.getString(s"system.$configKey.path.home")

--- a/peel-extensions/src/main/resources/reference.dstat-0.7.2.conf
+++ b/peel-extensions/src/main/resources/reference.dstat-0.7.2.conf
@@ -3,7 +3,7 @@ include "reference.dstat.conf"
 system {
     dstat {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://fossies.org/linux/privat/dstat-0.7.2.tar.gz"
             archive.md5 = "f4597fa0b0e9997f4a97a44ff1b688b6"
             archive.src = ${app.path.downloads}"/dstat-0.7.2.tar.gz"

--- a/peel-extensions/src/main/resources/reference.dstat-0.7.2.conf
+++ b/peel-extensions/src/main/resources/reference.dstat-0.7.2.conf
@@ -3,6 +3,7 @@ include "reference.dstat.conf"
 system {
     dstat {
         path {
+						isShared = false
             archive.url = "http://fossies.org/linux/privat/dstat-0.7.2.tar.gz"
             archive.md5 = "f4597fa0b0e9997f4a97a44ff1b688b6"
             archive.src = ${app.path.downloads}"/dstat-0.7.2.tar.gz"

--- a/peel-extensions/src/main/resources/reference.dstat-0.7.2.conf
+++ b/peel-extensions/src/main/resources/reference.dstat-0.7.2.conf
@@ -3,7 +3,7 @@ include "reference.dstat.conf"
 system {
     dstat {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://fossies.org/linux/privat/dstat-0.7.2.tar.gz"
             archive.md5 = "f4597fa0b0e9997f4a97a44ff1b688b6"
             archive.src = ${app.path.downloads}"/dstat-0.7.2.tar.gz"

--- a/peel-extensions/src/main/resources/reference.dstat.conf
+++ b/peel-extensions/src/main/resources/reference.dstat.conf
@@ -4,6 +4,7 @@ system {
         group = ${system.default.group}
 
         path {
+						isShared = false
             archive.dst = ${app.path.systems}
             pids = ${java.io.tmpdir}"/dstat/dstat.pids"
             conf = ${system.dstat.path.home}

--- a/peel-extensions/src/main/resources/reference.dstat.conf
+++ b/peel-extensions/src/main/resources/reference.dstat.conf
@@ -4,7 +4,7 @@ system {
         group = ${system.default.group}
 
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
             pids = ${java.io.tmpdir}"/dstat/dstat.pids"
             conf = ${system.dstat.path.home}

--- a/peel-extensions/src/main/resources/reference.dstat.conf
+++ b/peel-extensions/src/main/resources/reference.dstat.conf
@@ -4,7 +4,7 @@ system {
         group = ${system.default.group}
 
         path {
-						isShared = false
+            isShared = false
             archive.dst = ${app.path.systems}
             pids = ${java.io.tmpdir}"/dstat/dstat.pids"
             conf = ${system.dstat.path.home}

--- a/peel-extensions/src/main/resources/reference.flink-0.10.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.0.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "840e6017a19ec5d60fc7eac6da21e9a1"
             archive.src = ${app.path.downloads}"/flink-0.10.0-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "840e6017a19ec5d60fc7eac6da21e9a1"
             archive.src = ${app.path.downloads}"/flink-0.10.0-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.0/flink-0.10.0-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "840e6017a19ec5d60fc7eac6da21e9a1"
             archive.src = ${app.path.downloads}"/flink-0.10.0-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "fbce243da19ff01fad0be46bdf780bbc"
             archive.src = ${app.path.downloads}"/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "fbce243da19ff01fad0be46bdf780bbc"
             archive.src = ${app.path.downloads}"/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.1.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.1/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "fbce243da19ff01fad0be46bdf780bbc"
             archive.src = ${app.path.downloads}"/flink-0.10.1-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.2.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-bin-hadoop2.tgz"
             archive.md5 = "ee29eff3299b1ae1eeffb4d3eb0db1f7"
             archive.src = ${app.path.downloads}"/flink-0.10.2-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.2.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-bin-hadoop2.tgz"
             archive.md5 = "ee29eff3299b1ae1eeffb4d3eb0db1f7"
             archive.src = ${app.path.downloads}"/flink-0.10.2-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.10.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.10.2.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-0.10.2/flink-0.10.2-bin-hadoop2.tgz"
             archive.md5 = "ee29eff3299b1ae1eeffb4d3eb0db1f7"
             archive.src = ${app.path.downloads}"/flink-0.10.2-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.8.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.8.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz"
             archive.md5 = "9f79a5b7baaa82aea80e783fadc50f00"
             archive.src = ${app.path.downloads}"/flink-0.8.0-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.8.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.8.0.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz"
             archive.md5 = "9f79a5b7baaa82aea80e783fadc50f00"
             archive.src = ${app.path.downloads}"/flink-0.8.0-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.8.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.8.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.8.0/flink-0.8.0-bin-hadoop2.tgz"
             archive.md5 = "9f79a5b7baaa82aea80e783fadc50f00"
             archive.src = ${app.path.downloads}"/flink-0.8.0-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.8.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.8.1.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz"
             archive.md5 = "e8fa788f18157eae5675d189f409bc5a"
             archive.src = ${app.path.downloads}"/flink-0.8.1-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.8.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.8.1.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz"
             archive.md5 = "e8fa788f18157eae5675d189f409bc5a"
             archive.src = ${app.path.downloads}"/flink-0.8.1-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.8.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.8.1.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-0.8.1/flink-0.8.1-bin-hadoop2.tgz"
             archive.md5 = "e8fa788f18157eae5675d189f409bc5a"
             archive.src = ${app.path.downloads}"/flink-0.8.1-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.9.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.9.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz"
             archive.md5 = "17571b60fc2d400a6c935a6c4ad71cd4"
             archive.src = ${app.path.downloads}"/flink-0.9.0-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.9.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.9.0.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz"
             archive.md5 = "17571b60fc2d400a6c935a6c4ad71cd4"
             archive.src = ${app.path.downloads}"/flink-0.9.0-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-0.9.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-0.9.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-0.9.0/flink-0.9.0-bin-hadoop2.tgz"
             archive.md5 = "17571b60fc2d400a6c935a6c4ad71cd4"
             archive.src = ${app.path.downloads}"/flink-0.9.0-bin-hadoop2.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "a9a0b92029755894f0d1b448549254b3"
             archive.src = ${app.path.downloads}"/flink-1.0.0-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.0.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "a9a0b92029755894f0d1b448549254b3"
             archive.src = ${app.path.downloads}"/flink-1.0.0-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.0.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.0.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.0/flink-1.0.0-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "a9a0b92029755894f0d1b448549254b3"
             archive.src = ${app.path.downloads}"/flink-1.0.0-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.1.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "2dc1f4dd15f42fa6920b61ad538b61a6"
             archive.src = ${app.path.downloads}"/flink-1.0.1-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.1.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "2dc1f4dd15f42fa6920b61ad538b61a6"
             archive.src = ${app.path.downloads}"/flink-1.0.1-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.1.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.1.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.1/flink-1.0.1-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "2dc1f4dd15f42fa6920b61ad538b61a6"
             archive.src = ${app.path.downloads}"/flink-1.0.1-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.2.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "64643f05bffe87f023562a75b4aba252"
             archive.src = ${app.path.downloads}"/flink-1.0.2-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.2.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "64643f05bffe87f023562a75b4aba252"
             archive.src = ${app.path.downloads}"/flink-1.0.2-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.2.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.2.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.2/flink-1.0.2-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "64643f05bffe87f023562a75b4aba252"
             archive.src = ${app.path.downloads}"/flink-1.0.2-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.3.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.3.conf
@@ -4,6 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "9f6caadf2ed585e972f83baa7f1ee0dd"
             archive.src = ${app.path.downloads}"/flink-1.0.3-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.3.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.3.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "9f6caadf2ed585e972f83baa7f1ee0dd"
             archive.src = ${app.path.downloads}"/flink-1.0.3-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink-1.0.3.conf
+++ b/peel-extensions/src/main/resources/reference.flink-1.0.3.conf
@@ -4,7 +4,7 @@ include "reference.flink.conf"
 system {
     flink {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/flink/flink-1.0.3/flink-1.0.3-bin-hadoop2-scala_2.10.tgz"
             archive.md5 = "9f6caadf2ed585e972f83baa7f1ee0dd"
             archive.src = ${app.path.downloads}"/flink-1.0.3-bin-hadoop2-scala_2.10.tgz"

--- a/peel-extensions/src/main/resources/reference.flink.conf
+++ b/peel-extensions/src/main/resources/reference.flink.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-						isShared = false
+            isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.flink.path.home}"/conf"
             log = ${system.flink.path.home}"/log"

--- a/peel-extensions/src/main/resources/reference.flink.conf
+++ b/peel-extensions/src/main/resources/reference.flink.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
             config = ${system.flink.path.home}"/conf"
             log = ${system.flink.path.home}"/log"

--- a/peel-extensions/src/main/resources/reference.flink.conf
+++ b/peel-extensions/src/main/resources/reference.flink.conf
@@ -3,6 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
+						isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.flink.path.home}"/conf"
             log = ${system.flink.path.home}"/log"

--- a/peel-extensions/src/main/resources/reference.hadoop-1.x.conf
+++ b/peel-extensions/src/main/resources/reference.hadoop-1.x.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-						isShared = false
+            isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.hadoop-1.path.home}"/conf"
             log = ${system.hadoop-1.path.home}"/logs"

--- a/peel-extensions/src/main/resources/reference.hadoop-1.x.conf
+++ b/peel-extensions/src/main/resources/reference.hadoop-1.x.conf
@@ -3,6 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
+						isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.hadoop-1.path.home}"/conf"
             log = ${system.hadoop-1.path.home}"/logs"

--- a/peel-extensions/src/main/resources/reference.hadoop-1.x.conf
+++ b/peel-extensions/src/main/resources/reference.hadoop-1.x.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
             config = ${system.hadoop-1.path.home}"/conf"
             log = ${system.hadoop-1.path.home}"/logs"

--- a/peel-extensions/src/main/resources/reference.hadoop-2.x.conf
+++ b/peel-extensions/src/main/resources/reference.hadoop-2.x.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-						isShared = false
+            isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.hadoop-2.path.home}"/etc/hadoop"
             log = ${system.hadoop-2.path.home}"/logs"

--- a/peel-extensions/src/main/resources/reference.hadoop-2.x.conf
+++ b/peel-extensions/src/main/resources/reference.hadoop-2.x.conf
@@ -3,6 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
+						isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.hadoop-2.path.home}"/etc/hadoop"
             log = ${system.hadoop-2.path.home}"/logs"

--- a/peel-extensions/src/main/resources/reference.hadoop-2.x.conf
+++ b/peel-extensions/src/main/resources/reference.hadoop-2.x.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
             config = ${system.hadoop-2.path.home}"/etc/hadoop"
             log = ${system.hadoop-2.path.home}"/logs"

--- a/peel-extensions/src/main/resources/reference.hdfs-1.2.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-1.2.1.conf
@@ -4,6 +4,7 @@ include "reference.hadoop-1.x.conf"
 system {
     hadoop-1 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/common/hadoop-1.2.1/hadoop-1.2.1.tar.gz"
             archive.md5 = "8D7904805617C16CB227D1CCBFE9385A"
             archive.src = ${app.path.downloads}"/hadoop-1.2.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-1.2.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-1.2.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-1.x.conf"
 system {
     hadoop-1 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/common/hadoop-1.2.1/hadoop-1.2.1.tar.gz"
             archive.md5 = "8D7904805617C16CB227D1CCBFE9385A"
             archive.src = ${app.path.downloads}"/hadoop-1.2.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-1.2.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-1.2.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-1.x.conf"
 system {
     hadoop-1 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/common/hadoop-1.2.1/hadoop-1.2.1.tar.gz"
             archive.md5 = "8D7904805617C16CB227D1CCBFE9385A"
             archive.src = ${app.path.downloads}"/hadoop-1.2.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-2.4.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-2.4.1.conf
@@ -4,6 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-2.4.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-2.7.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-2.7.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
             archive.md5 = "203E5B4DAF1C5658C3386A32C4BE5531"
             archive.src = ${app.path.downloads}"/hadoop-2.7.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-2.7.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-2.7.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
             archive.md5 = "203E5B4DAF1C5658C3386A32C4BE5531"
             archive.src = ${app.path.downloads}"/hadoop-2.7.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.hdfs-2.7.1.conf
+++ b/peel-extensions/src/main/resources/reference.hdfs-2.7.1.conf
@@ -4,6 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
             archive.md5 = "203E5B4DAF1C5658C3386A32C4BE5531"
             archive.src = ${app.path.downloads}"/hadoop-2.7.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.mapred-1.2.1.conf
+++ b/peel-extensions/src/main/resources/reference.mapred-1.2.1.conf
@@ -4,6 +4,7 @@ include "reference.hadoop-1.x.conf"
 system {
     hadoop-1 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/common/hadoop-1.2.1/hadoop-1.2.1.tar.gz"
             archive.md5 = "8D7904805617C16CB227D1CCBFE9385A"
             archive.src = ${app.path.downloads}"/hadoop-1.2.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.mapred-1.2.1.conf
+++ b/peel-extensions/src/main/resources/reference.mapred-1.2.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-1.x.conf"
 system {
     hadoop-1 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/common/hadoop-1.2.1/hadoop-1.2.1.tar.gz"
             archive.md5 = "8D7904805617C16CB227D1CCBFE9385A"
             archive.src = ${app.path.downloads}"/hadoop-1.2.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.mapred-1.2.1.conf
+++ b/peel-extensions/src/main/resources/reference.mapred-1.2.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-1.x.conf"
 system {
     hadoop-1 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/common/hadoop-1.2.1/hadoop-1.2.1.tar.gz"
             archive.md5 = "8D7904805617C16CB227D1CCBFE9385A"
             archive.src = ${app.path.downloads}"/hadoop-1.2.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.mapred-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.mapred-2.4.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.mapred-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.mapred-2.4.1.conf
@@ -4,6 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.mapred-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.mapred-2.4.1.conf
@@ -4,7 +4,7 @@ include "reference.hadoop-2.x.conf"
 system {
     hadoop-2 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.spark-1.3.1.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.3.1.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz"
             archive.md5 = "BA1072F910DA6C8708FB7C8B00B3D378"
             archive.src = ${app.path.downloads}"/spark-1.3.1-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.3.1.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.3.1.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz"
             archive.md5 = "BA1072F910DA6C8708FB7C8B00B3D378"
             archive.src = ${app.path.downloads}"/spark-1.3.1-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.3.1.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.3.1.conf
@@ -4,6 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.3.1/spark-1.3.1-bin-hadoop2.4.tgz"
             archive.md5 = "BA1072F910DA6C8708FB7C8B00B3D378"
             archive.src = ${app.path.downloads}"/spark-1.3.1-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.4.0.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.4.0.conf
@@ -4,6 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz"
             archive.md5 = "4B0BDB1D30020DD4FFF18B02AC675EB3"
             archive.src = ${app.path.downloads}"/spark-1.4.0-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.4.0.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.4.0.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz"
             archive.md5 = "4B0BDB1D30020DD4FFF18B02AC675EB3"
             archive.src = ${app.path.downloads}"/spark-1.4.0-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.4.0.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.4.0.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/spark/spark-1.4.0/spark-1.4.0-bin-hadoop2.4.tgz"
             archive.md5 = "4B0BDB1D30020DD4FFF18B02AC675EB3"
             archive.src = ${app.path.downloads}"/spark-1.4.0-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.5.1.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.5.1.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/spark/spark-1.5.1/spark-1.5.1-bin-hadoop2.4.tgz"
             archive.md5 = "12A26D5896A2D4F2746763E86A123C4E"
             archive.src = ${app.path.downloads}"/spark-1.5.1-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.5.1.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.5.1.conf
@@ -4,6 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.5.1/spark-1.5.1-bin-hadoop2.4.tgz"
             archive.md5 = "12A26D5896A2D4F2746763E86A123C4E"
             archive.src = ${app.path.downloads}"/spark-1.5.1-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.5.1.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.5.1.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.5.1/spark-1.5.1-bin-hadoop2.4.tgz"
             archive.md5 = "12A26D5896A2D4F2746763E86A123C4E"
             archive.src = ${app.path.downloads}"/spark-1.5.1-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.5.2.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.5.2.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/spark/spark-1.5.2/spark-1.5.2-bin-hadoop2.4.tgz"
             archive.md5 = "963CB2CB56DEE4C72B7E1135CA3E614C"
             archive.src = ${app.path.downloads}"/spark-1.5.2-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.5.2.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.5.2.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.5.2/spark-1.5.2-bin-hadoop2.4.tgz"
             archive.md5 = "963CB2CB56DEE4C72B7E1135CA3E614C"
             archive.src = ${app.path.downloads}"/spark-1.5.2-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.5.2.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.5.2.conf
@@ -4,6 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.5.2/spark-1.5.2-bin-hadoop2.4.tgz"
             archive.md5 = "963CB2CB56DEE4C72B7E1135CA3E614C"
             archive.src = ${app.path.downloads}"/spark-1.5.2-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.6.0.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.6.0.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.4.tgz"
             archive.md5 = "74083148CE6AF63B2983A903D6DFFDF5"
             archive.src = ${app.path.downloads}"/spark-1.6.0-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.6.0.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.6.0.conf
@@ -4,7 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.4.tgz"
             archive.md5 = "74083148CE6AF63B2983A903D6DFFDF5"
             archive.src = ${app.path.downloads}"/spark-1.6.0-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark-1.6.0.conf
+++ b/peel-extensions/src/main/resources/reference.spark-1.6.0.conf
@@ -4,6 +4,7 @@ include "reference.spark.conf"
 system {
     spark {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/spark/spark-1.6.0/spark-1.6.0-bin-hadoop2.4.tgz"
             archive.md5 = "74083148CE6AF63B2983A903D6DFFDF5"
             archive.src = ${app.path.downloads}"/spark-1.6.0-bin-hadoop2.4.tgz"

--- a/peel-extensions/src/main/resources/reference.spark.conf
+++ b/peel-extensions/src/main/resources/reference.spark.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
             home = ${app.path.systems}"/spark"
             config = ${system.spark.path.home}"/conf"

--- a/peel-extensions/src/main/resources/reference.spark.conf
+++ b/peel-extensions/src/main/resources/reference.spark.conf
@@ -3,6 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
+						isShared = false
             archive.dst = ${app.path.systems}
             home = ${app.path.systems}"/spark"
             config = ${system.spark.path.home}"/conf"

--- a/peel-extensions/src/main/resources/reference.spark.conf
+++ b/peel-extensions/src/main/resources/reference.spark.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-						isShared = false
+            isShared = false
             archive.dst = ${app.path.systems}
             home = ${app.path.systems}"/spark"
             config = ${system.spark.path.home}"/conf"

--- a/peel-extensions/src/main/resources/reference.yarn-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.yarn-2.4.1.conf
@@ -4,6 +4,7 @@ include "reference.yarn-2.x.conf"
 system {
     hadoop-2 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.yarn-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.yarn-2.4.1.conf
@@ -4,7 +4,7 @@ include "reference.yarn-2.x.conf"
 system {
     hadoop-2 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.yarn-2.4.1.conf
+++ b/peel-extensions/src/main/resources/reference.yarn-2.4.1.conf
@@ -4,7 +4,7 @@ include "reference.yarn-2.x.conf"
 system {
     hadoop-2 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.4.1/hadoop-2.4.1.tar.gz"
             archive.md5 = "0CE4CFD282002B7AA42CF71DF4145150"
             archive.src = ${app.path.downloads}"/hadoop-2.4.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.yarn-2.7.1.conf
+++ b/peel-extensions/src/main/resources/reference.yarn-2.7.1.conf
@@ -4,7 +4,7 @@ include "reference.yarn-2.x.conf"
 system {
     hadoop-2 {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
             archive.md5 = "203E5B4DAF1C5658C3386A32C4BE5531"
             archive.src = ${app.path.downloads}"/hadoop-2.7.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.yarn-2.7.1.conf
+++ b/peel-extensions/src/main/resources/reference.yarn-2.7.1.conf
@@ -4,7 +4,7 @@ include "reference.yarn-2.x.conf"
 system {
     hadoop-2 {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
             archive.md5 = "203E5B4DAF1C5658C3386A32C4BE5531"
             archive.src = ${app.path.downloads}"/hadoop-2.7.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.yarn-2.7.1.conf
+++ b/peel-extensions/src/main/resources/reference.yarn-2.7.1.conf
@@ -4,6 +4,7 @@ include "reference.yarn-2.x.conf"
 system {
     hadoop-2 {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/hadoop/core/hadoop-2.7.1/hadoop-2.7.1.tar.gz"
             archive.md5 = "203E5B4DAF1C5658C3386A32C4BE5531"
             archive.src = ${app.path.downloads}"/hadoop-2.7.1.tar.gz"

--- a/peel-extensions/src/main/resources/reference.zookeeper-3.4.5.conf
+++ b/peel-extensions/src/main/resources/reference.zookeeper-3.4.5.conf
@@ -4,7 +4,7 @@ include "reference.zookeeper.conf"
 system {
     zookeeper {
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.url = "http://archive.apache.org/dist/zookeeper/zookeeper-3.4.5/zookeeper-3.4.5.tar.gz"
             archive.md5 = "f64fef86c0bf2e5e0484d19425b22dcb"
             archive.src = ${app.path.downloads}"/zookeeper-3.4.5.tar.gz"

--- a/peel-extensions/src/main/resources/reference.zookeeper-3.4.5.conf
+++ b/peel-extensions/src/main/resources/reference.zookeeper-3.4.5.conf
@@ -4,7 +4,7 @@ include "reference.zookeeper.conf"
 system {
     zookeeper {
         path {
-						isShared = false
+            isShared = false
             archive.url = "http://archive.apache.org/dist/zookeeper/zookeeper-3.4.5/zookeeper-3.4.5.tar.gz"
             archive.md5 = "f64fef86c0bf2e5e0484d19425b22dcb"
             archive.src = ${app.path.downloads}"/zookeeper-3.4.5.tar.gz"

--- a/peel-extensions/src/main/resources/reference.zookeeper-3.4.5.conf
+++ b/peel-extensions/src/main/resources/reference.zookeeper-3.4.5.conf
@@ -4,6 +4,7 @@ include "reference.zookeeper.conf"
 system {
     zookeeper {
         path {
+						isShared = false
             archive.url = "http://archive.apache.org/dist/zookeeper/zookeeper-3.4.5/zookeeper-3.4.5.tar.gz"
             archive.md5 = "f64fef86c0bf2e5e0484d19425b22dcb"
             archive.src = ${app.path.downloads}"/zookeeper-3.4.5.tar.gz"

--- a/peel-extensions/src/main/resources/reference.zookeeper.conf
+++ b/peel-extensions/src/main/resources/reference.zookeeper.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-            isShared = false
+            isShared = ${system.default.path.isShared}
             archive.dst = ${app.path.systems}
             config = ${system.zookeeper.path.home}"/conf"
             data = ${system.zookeeper.path.home}"/data"

--- a/peel-extensions/src/main/resources/reference.zookeeper.conf
+++ b/peel-extensions/src/main/resources/reference.zookeeper.conf
@@ -3,7 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
-						isShared = false
+            isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.zookeeper.path.home}"/conf"
             data = ${system.zookeeper.path.home}"/data"

--- a/peel-extensions/src/main/resources/reference.zookeeper.conf
+++ b/peel-extensions/src/main/resources/reference.zookeeper.conf
@@ -3,6 +3,7 @@ system {
         user = ${system.default.user}
         group = ${system.default.group}
         path {
+						isShared = false
             archive.dst = ${app.path.systems}
             config = ${system.zookeeper.path.home}"/conf"
             data = ${system.zookeeper.path.home}"/data"


### PR DESCRIPTION
The Peel framework assumes that all nodes within a cluster share the same disk for experiment execution. 

We at FG INET together with Niklas Semmler wanted to use Peel to execute our experiments in an environment where all nodes use their one dedicated disks. We added support for clusters with no shared disk by using rsync to copy the 'systems' directory in an experiment bundle to all slave nodes configured in `hosts.conf` file. We added a new parameter `sytem.default.config.noSharedDisk` to `reference.peel.conf` to make this feature configurable. The default value is `false` if it is not present or set in `application.conf` file. In this case the behavior of Peel is still the same. If the parameter is set in `application.conf` the systems folder will be copied remote hosts. 

Feedback from the Peel team is very welcome. 