### PR TITLE
Also teardown systems with Lifespan.RUN through sys:teardown

### DIFF
--- a/peel-core/src/main/scala/org/peelframework/core/cli/command/experiment/TearDown.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/cli/command/experiment/TearDown.scala
@@ -66,7 +66,7 @@ class TearDown extends Command {
     // find experiment
     val expOption = suite.experiments.find(_.name == expName)
     // check if experiment exists (the list should contain exactly one element)
-    if (expOption.isEmpty) throw new RuntimeException(s"Experiment '$expName' either not found or ambigous in suite '$suiteName'")
+    if (expOption.isEmpty) throw new RuntimeException(s"Experiment '$expName' either not found or ambiguous in suite '$suiteName'")
 
     for (exp <- expOption) {
       // update config
@@ -78,7 +78,7 @@ class TearDown extends Command {
 
       logger.info("Tearing down systems for experiment '%s'".format(exp.name))
       for (n <- graph.traverse(); if graph.descendants(exp).contains(n)) n match {
-        case s: System if Lifespan.SUITE :: Lifespan.EXPERIMENT :: Nil contains s.lifespan => s.tearDown()
+        case s: System if Lifespan.SUITE :: Lifespan.EXPERIMENT :: Lifespan.RUN :: Nil contains s.lifespan => s.tearDown()
         case _ => Unit
       }
     }

--- a/peel-core/src/main/scala/org/peelframework/core/cli/command/system/TearDown.scala
+++ b/peel-core/src/main/scala/org/peelframework/core/cli/command/system/TearDown.scala
@@ -48,7 +48,7 @@ class TearDown extends Command {
   override def run(context: ApplicationContext) = {
     val systemID = Sys.getProperty("app.system.id")
 
-    logger.info(s"Tearing down system '$systemID' and dependencies with SUITE or EXPERIMENT lifespan")
+    logger.info(s"Tearing down system '$systemID' and dependencies managed by peel")
     val sys = context.getBean(systemID, classOf[System])
     val graph = createGraph(sys)
 
@@ -61,7 +61,7 @@ class TearDown extends Command {
 
     // tear down
     for (n <- graph.traverse(); if graph.descendants(sys).contains(n)) n match {
-      case s: System if Lifespan.SUITE :: Lifespan.EXPERIMENT :: Nil contains s.lifespan => s.tearDown()
+      case s: System if Lifespan.SUITE :: Lifespan.EXPERIMENT :: Lifespan.RUN :: Nil contains s.lifespan => s.tearDown()
       case _ => Unit
     }
   }


### PR DESCRIPTION
Sometimes it's necessary to abort experiments (ctrl+c). Then using `sys:teardown` allows to stop systems, yet it currently does not include systems with `Lifespan.RUN`.

I've many experiments in which Flink depends on dstat and HDFS. dstat is set to `Lifespan.RUN` (as in the reference config). After aborting experiments, i can use `sys:teardown` to stop Flink and HDFS, but always have to remember to stop dstat manually (and delete the PIDs peel stored).

Can we add Lifespan.RUN to `sys:teardown`? Or is there a good reason not to do this?

/cc @akunft 