### PR TITLE
Trigger rebuild of Peel documentation

### DIFF
--- a/_manual/experiments-definitions.md
+++ b/_manual/experiments-definitions.md
@@ -104,6 +104,8 @@ The `peel-extensions` module ships with several *System* implementations. The fo
 | HDFS             | 1.2.1          | hdfs-1.2.1      |
 | HDFS             | 2.4.1          | hdfs-2.4.1      |
 | HDFS             | 2.7.1          | hdfs-2.7.1      |
+| HDFS             | 3.1.1          | hdfs-3.1.1      |
+| Yarn             | 3.1.1          | yarn-3.1.1      |
 | Flink            | 0.8.0          | flink-0.8.0     |
 | Flink            | 0.8.1          | flink-0.8.1     |
 | Flink            | 0.9.0          | flink-0.9.0     |
@@ -120,6 +122,10 @@ The `peel-extensions` module ships with several *System* implementations. The fo
 | Flink            | 1.1.3          | flink-1.1.3     |
 | Flink            | 1.1.4          | flink-1.1.4     |
 | Flink            | 1.2.0          | flink-1.2.0     |
+| Flink Standalone Cluster | 1.7.0  | flink-1.7.0     |
+| Flink Standalone Cluster | 1.7.2  | flink-1.7.2     |
+| Flink Yarn Session | 1.7.0        | flink-yarn-1.7.0 |
+| Flink Yarn Session | 1.7.2        | flink-yarn-1.7.2 |
 | MapReduce        | 1.2.1          | mapred-1.2.1    |
 | MapReduce        | 2.4.1          | mapred-2.4.1    |
 | Spark            | 1.3.1          | spark-1.3.1     |


### PR DESCRIPTION
Added some new bean definitions to trigger documentation rebuild. This should fix the broken XML and Scala examples.